### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -1,4 +1,6 @@
 name: Deploy Worker
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/xixu-me/Xget/security/code-scanning/8](https://github.com/xixu-me/Xget/security/code-scanning/8)

To fix the problem, you should set an explicit `permissions` block in the workflow to limit the GITHUB_TOKEN’s permissions. Place the `permissions` block at the root level of the YAML, below `name:` and before `on:`. This ensures that every job in the workflow inherits minimal permissions unless overridden. For most deployment jobs that use third-party tokens, the GITHUB_TOKEN usually only needs `contents: read` to allow checkout and dependencies, unless writing to the repository or making API changes. The fix requires adding just a few lines at the top of the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
