### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete regular expression for hostnames

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1245,7 +1245,7 @@ async function handleRequest(request, env, ctx) {
       // Rewrite URLs in the response body to go through the Cloudflare Workers
       // files.pythonhosted.org URLs should be rewritten to go through our pypi/files endpoint
       const rewrittenText = originalText.replace(
-        /https:\/\/files.pythonhosted.org/g,
+        /https:\/\/files\.pythonhosted\.org/g,
         `${url.origin}/pypi/files`
       );
       responseBody = new ReadableStream({


### PR DESCRIPTION
Potential fix for [https://github.com/xixu-me/xget/security/code-scanning/11](https://github.com/xixu-me/xget/security/code-scanning/11)

The problem occurs because the regular expression `/https:\/\/files.pythonhosted.org/g` uses an unescaped dot before `pythonhosted.org`, so it will match more than just the literal domain name. The fix is to escape the dot: `/https:\/\/files\.pythonhosted\.org/g`. This change restricts the regex to only match URLs targeting the literal host `files.pythonhosted.org`, avoiding matching unintended hosts.

Apply this change only in the line where the regex appears in the context of PyPI URL rewriting within `src/index.js`, at or around line 1248. No additional imports or method changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
