### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/xixu-me/xget/security/code-scanning/13](https://github.com/xixu-me/xget/security/code-scanning/13)

To fix the problem, add an explicit `permissions` block to the workflow, either at the root (to apply to all jobs) or inside the `test` job (to apply to this specific job). As there is only one job shown (`test`), both approaches are valid, but it is slightly preferred to set it at the root in case more jobs are added in the future that also don't require write access. The following change should be made: add

```yaml
permissions:
  contents: read
```

immediately after the workflow's `name`, before the `on:` block (line 2 or 3). This will ensure that the workflow only grants read access to repository contents, adhering to the principle of least privilege.

No additional libraries, methods, or definitions are needed. This is a YAML config change only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
