### PR TITLE
Potential fix for code scanning alert no. 17: Information exposure through a stack trace

### DIFF
--- a/src/protocols/docker.js
+++ b/src/protocols/docker.js
@@ -262,7 +262,10 @@ export async function handleDockerAuth(request, url, config) {
   try {
     target = resolveDockerAuthTarget(url, config.PLATFORMS);
   } catch (error) {
-    return createErrorResponse(error instanceof Error ? error.message : String(error), 400);
+    // Log internal error details server-side without exposing them to the client
+    console.error('Failed to resolve Docker auth target:', error);
+    // Return a generic error response to avoid leaking implementation details
+    return createErrorResponse('Invalid Docker authentication request', 400);
   }
 
   const upstreamUrl = config.PLATFORMS[target.platformKey];


### PR DESCRIPTION
Potential fix for [https://github.com/xixu-me/xget/security/code-scanning/17](https://github.com/xixu-me/xget/security/code-scanning/17)

In general, the fix is to avoid sending raw error messages (which may contain stack-trace-like or sensitive details) directly to the client. Instead, return a generic, user-safe message and, if needed, log the full error server-side. Specifically here, `handleDockerAuth` should not pass `error.message` into `createErrorResponse`; it should send a stable, generic message such as `"Invalid Docker authentication request"` while logging the actual `error`.

The best targeted change without altering external behavior elsewhere is:
- Update `handleDockerAuth`’s `catch` block in `src/protocols/docker.js` so that:
  - The HTTP response body contains a generic message (e.g. `"Invalid Docker authentication request"`).
  - The original error is logged to the console (or another logging sink) using `console.error`, which is available without extra imports.
- Leave `createErrorResponse` unchanged so other callers can still use it as-is, including its `includeDetails` parameter.

Concretely:
- In `src/protocols/docker.js`, replace the `catch (error) { ... }` block around line 264–266 with:
  - A `console.error('Failed to resolve Docker auth target:', error);`
  - A call to `createErrorResponse('Invalid Docker authentication request', 400);`
This prevents error messages (and any embedded stack-ish data) from flowing into `errorBody` and back to the client.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
